### PR TITLE
Run ansible-doc remotely through TRAMP

### DIFF
--- a/ansible-doc.el
+++ b/ansible-doc.el
@@ -137,8 +137,10 @@ buffer-local wherever it is set."
     (message "Finding Ansible modules...")
     (with-temp-buffer
       (when (with-demoted-errors "Error while finding Ansible modules: %S"
-              (let ((retcode (call-process "ansible-doc" nil t nil "--list")))
-                (unless (equal retcode 0)
+              (let ((retcode (process-file-shell-command
+                              "env PAGER=cat ansible-doc" nil t nil "--list")))
+                (if (equal retcode 0)
+                    t
                   (error "Command ansible-doc --list failed with code %s, returned %s"
                          retcode (buffer-string)))))
         (goto-char (point-max))
@@ -274,7 +276,7 @@ Return a fontified copy of TEXT."
       (message "Loading documentation for module %s" module)
       (let ((inhibit-read-only t))
         (erase-buffer)
-        (call-process "ansible-doc" nil t t module)
+        (process-file-shell-command "env PAGER=cat ansible-doc" nil t t module)
         (let ((delete-trailing-lines t))
           (delete-trailing-whitespace))
         (ansible-doc-fontify-yaml-examples))


### PR DESCRIPTION
If the current buffer is visiting a remote file through TRAMP, run `ansible-doc` on that remote host.

We need to set environment variable `PAGER=cat`, otherwise `ansible-doc` will detect that it's running on a TTY and pipe itself to `less`, never returning.