### PR TITLE
Prevent ANSI color codes from being inserted into the buffer

### DIFF
--- a/ansible-doc.el
+++ b/ansible-doc.el
@@ -262,7 +262,11 @@ If NOCONFIRM is non-nil revert without prompt."
     (when (or noconfirm
               (y-or-n-p (format "Reload documentation for %s? " module)))
       (message "Loading documentation for module %s" module)
-      (let ((inhibit-read-only t))
+      (let ((inhibit-read-only t)
+            ;; Prevent ANSI color codes from being inserted into the buffer,
+            ;; which would otherwise display as raw escape sequences.
+            (process-environment (cons "ANSIBLE_NOCOLOR=1"
+                                       process-environment)))
         (erase-buffer)
         (call-process "ansible-doc" nil t t module)
         (let ((delete-trailing-lines t))


### PR DESCRIPTION
This pull request prevents ANSI color codes from being inserted into the buffer, which would otherwise display as raw escape sequences.

Without this pull request (The issue):
![Screenshot From 2025-04-15 10-40-29](https://github.com/user-attachments/assets/c908168f-e766-411a-a0fe-f063fff9a6f8)

With this pull request merged:
![Screenshot From 2025-04-15 10-40-10](https://github.com/user-attachments/assets/e75b6882-496f-4fae-865f-ef64a0028e46)
